### PR TITLE
LoRA Table of Contents / Homepage tweaks

### DIFF
--- a/docs/lora_list.mdx
+++ b/docs/lora_list.mdx
@@ -1,10 +1,24 @@
 import loraList from './loras.json';
-import LoRA from '../src/components/LoRA';
+import LoRA from '@site/src/components/LoRA';
+import { slugifyName } from '@site/src/utils';
 
-# LoRAs
+# The Video LoRA List
 
 A LoRA (Low-Rank Adaptation) is a set of weights which are trained on top of a base model using supplementary data. This technique can be used to create LoRAs which apply coherent cinematic styles, camera movements, facial expressions, faces, characters, and other concepts to a base diffusion / animation model.
 
 _Note_: Special thanks to contrinsan for providing this data!
 
-{loraList.map((category) => (<div><h2>{category.name}</h2>{category.entries.map((lora) => (<LoRA key={lora.name} {...lora} />))}</div>))}
+{loraList.map((category) => (<div><h2 id={slugifyName(category.name)}>{category.name}</h2>{category.entries.map((lora) => (<LoRA key={lora.name} {...lora} />))}</div>))}
+
+export const toc = loraList.flatMap((category) => [
+  {
+    level: 2,
+    id: category.name.toLowerCase().replaceAll(/\s+/g, '_'),
+    value: category.name
+  },
+  ...category.entries.map((entry) => ({
+    level: 3,
+    id: entry.name.toLowerCase().replaceAll(/\s+/g, '_'),
+    value: entry.name
+  }))
+]);

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -87,6 +87,10 @@ const config: Config = {
           title: 'Docs',
           items: [
             {
+              label: 'Get Started',
+              to: '/docs/get_started'
+            },
+            {
               label: 'User Guide',
               to: '/docs/user_guide'
             }

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -15,7 +15,8 @@ import type { SidebarsConfig } from '@docusaurus/plugin-content-docs';
 const sidebars: SidebarsConfig = {
   navSidebar: [
     { type: 'doc', id: 'get_started', label: 'Get Started' },
-    { type: 'doc', id: 'user_guide', label: 'User Guide' }
+    { type: 'doc', id: 'user_guide', label: 'User Guide' },
+    { type: 'doc', id: 'lora_list', label: 'Video LoRA List' }
   ]
 };
 

--- a/src/components/LoRA/index.tsx
+++ b/src/components/LoRA/index.tsx
@@ -3,6 +3,7 @@ import {
   faQuestionCircle
 } from '@fortawesome/pro-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { slugifyName } from '@site/src/utils';
 
 export interface LoRAProps {
   name: string;
@@ -26,7 +27,7 @@ export default function LoRA({
   return (
     <div className="card margin-bottom--md">
       <div className="card__header">
-        <h3>{name}</h3>
+        <h3 id={slugifyName(name)}>{name}</h3>
       </div>
       <div className="card__body">
         <div className="container">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,9 +6,12 @@ import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
 import {
+  faBookAtlas,
   faCubes,
   faExcavator,
-  faRabbitRunning
+  faPlayCircle,
+  faRabbitRunning,
+  faToggleOn
 } from '@fortawesome/pro-solid-svg-icons';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -92,17 +95,24 @@ export default function Home(): ReactNode {
           />
           <div className={styles.buttons}>
             <Link
-              className="button button--secondary button--lg"
-              style={{ marginRight: 8 }}
+              className="button button--secondary button--lg margin-right--md"
               to="/docs/get_started"
             >
-              Get Started
+              <FontAwesomeIcon icon={faToggleOn} size="lg" /> Get Started
             </Link>
             <Link
-              className="button button--secondary button--lg"
+              className="button button--secondary button--lg margin-right--md"
               to="/docs/user_guide"
             >
-              User Guide
+              <FontAwesomeIcon icon={faBookAtlas} size="lg" /> User Guide
+            </Link>
+            <Link
+              className="button button--success button--lg"
+              rel="noopener noreferrer"
+              target="_blank"
+              to="https://pinokio.co/item.html?uri=https%3A%2F%2Fgithub.com%2Fcolinurbs%2FFP-Studio"
+            >
+              <FontAwesomeIcon icon={faPlayCircle} size="lg" /> Pinokio Install
             </Link>
           </div>
         </div>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,2 @@
+export const slugifyName = (name: string): string =>
+  name.trim().toLowerCase().replaceAll(/\s+/g, '_');


### PR DESCRIPTION
Make the table of contents work for the LoRA list page. Add it to the sidebar, add Get Started to the footer, add icons to homepage buttons and add a Pinokio install button there.

![image](https://github.com/user-attachments/assets/f31f3398-b17d-42f9-b50c-8577fa5465a4)

![image](https://github.com/user-attachments/assets/7e417d6a-ac29-4c2a-b256-501913d77d5f)
